### PR TITLE
Create Release on Push

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,7 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set current date as env variable
-        run: echo "time=$(date +'%Y%m%d%H')" >> $GITHUB_ENV
+        run: |
+          _ts=$(date -d '${{ github.event.head_commit.updated_at}}' +'%Y%m%d%H%M%S')
+          echo "target_tag=${_ts}" >> $GITHUB_ENV
       - name: Checkout main repo
         uses: actions/checkout@v2
         with:
@@ -72,7 +74,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set current date as env variable
-        run: echo "time=$(date +'%Y%m%d%H')" >> $GITHUB_ENV
+        run: |
+          _ts=$(date -d '${{ github.event.head_commit.updated_at}}' +'%Y%m%d%H%M%S')
+          echo "target_tag=${_ts}" >> $GITHUB_ENV
       - uses: chickensoft-games/setup-godot@v1
         name: Setup Godot
         with:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set current date as env variable
-        run: time=$(date +"%Y%m%d%H")" >> $GITHUB_ENV
+        run: echo "time=$(date +'%Y%m%d%H')" >> $GITHUB_ENV
       - name: Checkout main repo
         uses: actions/checkout@v2
         with:
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set current date as env variable
-        run: time=$(date +"%Y%m%d%H")" >> $GITHUB_ENV
+        run: echo "time=$(date +'%Y%m%d%H')" >> $GITHUB_ENV
       - uses: chickensoft-games/setup-godot@v1
         name: Setup Godot
         with:

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -63,6 +63,7 @@ jobs:
           zip -r ../windows.zip .
       - name: Upload binaries to release
         uses: softprops/action-gh-release@v1
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           files: build/windows.zip
           tag_name: ${{ env.target_tag }}
@@ -113,6 +114,7 @@ jobs:
           zip -r ../linux.zip .
       - name: Upload binaries to release
         uses: softprops/action-gh-release@v1
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
         with:
           files: build/linux.zip
           tag_name: ${{ env.target_tag }}

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -63,7 +63,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/windows.zip
-          tag_name: ${{ env.TIME }}
+          tag_name: ${{ env.time }}
           draft: false
           prerelease: true
           
@@ -111,6 +111,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/linux.zip
-          tag_name: ${{ env.TIME }}
+          tag_name: ${{ env.time }}
           draft: false
           prerelease: true

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - name: Set current date as env variable
         run: |
-          _ts=$(date -d '${{ github.event.head_commit.updated_at}}' +'%Y%m%d%H%M%S')
+          _ts=$(date -d '${{ github.event.head_commit.timestamp}}' +'%Y%m%d%H%M%S')
           echo "target_tag=${_ts}" >> $GITHUB_ENV
       - name: Checkout main repo
         uses: actions/checkout@v2
@@ -65,7 +65,7 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/windows.zip
-          tag_name: ${{ env.time }}
+          tag_name: ${{ env.target_tag }}
           draft: false
           prerelease: true
           
@@ -75,7 +75,7 @@ jobs:
     steps:
       - name: Set current date as env variable
         run: |
-          _ts=$(date -d '${{ github.event.head_commit.updated_at}}' +'%Y%m%d%H%M%S')
+          _ts=$(date -d '${{ github.event.head_commit.timestamp}}' +'%Y%m%d%H%M%S')
           echo "target_tag=${_ts}" >> $GITHUB_ENV
       - uses: chickensoft-games/setup-godot@v1
         name: Setup Godot
@@ -115,6 +115,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           files: build/linux.zip
-          tag_name: ${{ env.time }}
+          tag_name: ${{ env.target_tag }}
           draft: false
           prerelease: true

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -9,6 +9,8 @@ jobs:
     name: Windows Export
     runs-on: ubuntu-latest
     steps:
+      - name: Set current date as env variable
+        run: time=$(date +"%Y%m%d%H")" >> $GITHUB_ENV
       - name: Checkout main repo
         uses: actions/checkout@v2
         with:
@@ -49,11 +51,24 @@ jobs:
         with:
           name: windows
           path: build/windows/
+      - name: Create zip file
+        run: |
+          cd build/windows/
+          zip -r ../windows.zip .
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/windows.zip
+          tag_name: ${{ env.TIME }}
+          draft: false
+          prerelease: true
           
   export-linux:
     name: Linux Export
     runs-on: ubuntu-latest
     steps:
+      - name: Set current date as env variable
+        run: time=$(date +"%Y%m%d%H")" >> $GITHUB_ENV
       - uses: chickensoft-games/setup-godot@v1
         name: Setup Godot
         with:
@@ -84,3 +99,14 @@ jobs:
         with:
           name: linux
           path: build/linux
+      - name: Create zip file
+        run: |
+          cd build/linux/
+          zip -r ../linux.zip .
+      - name: Upload binaries to release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: build/linux.zip
+          tag_name: ${{ env.TIME }}
+          draft: false
+          prerelease: true

--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,5 +1,9 @@
 name: "godot-ci export"
-on: push
+on:
+  push:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 env:
   GODOT_VERSION: 4.2.1


### PR DESCRIPTION
Create a Github Release (available at [AdastralGroup/belmont/releases](https://github.com/adastralgroup/belmont/releases)) whenever a commit is pushed.

Currently, it generates a tag based off the latest commit (formatted as 'YYYYMMDDHHmmSS') and uploads the Windows and Linux release.

This ties in with my Steam Deck one-click-install script. ([see my gist](https://gist.github.com/ktwrd/1c7787c88c80509f096f08596d1683eb))